### PR TITLE
rds 인스턴스 크기 조정

### DIFF
--- a/apps/infrastructure/pulumi/aws/rds.ts
+++ b/apps/infrastructure/pulumi/aws/rds.ts
@@ -70,7 +70,7 @@ const instance = new aws.rds.ClusterInstance('readable-1', {
   identifier: 'readable-1',
 
   engine: 'aurora-postgresql',
-  instanceClass: 'db.t4g.medium',
+  instanceClass: 'db.r7g.large',
 
   availabilityZone: subnets.private.az1.availabilityZone,
   caCertIdentifier: 'rds-ca-ecc384-g1',


### PR DESCRIPTION
`db.t4g.medium` -> `db.r7g.large`
