### PR TITLE
ToastProvider를 portal로 topmost dialog에 넣음

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -39,6 +39,7 @@
     "noopener",
     "noreferrer",
     "oidcs",
+    "outroend",
     "penxle",
     "pulumi",
     "rabbitmq",

--- a/packages/ui/src/components/Alert.svelte
+++ b/packages/ui/src/components/Alert.svelte
@@ -3,7 +3,7 @@
   import { fade, fly } from 'svelte/transition';
   import { scrollLock } from '../actions';
   import Button from './Button.svelte';
-  import Dialog from './Dialog.svelte';
+  import Dialog from './dialog/Dialog.svelte';
   import type { SystemStyleObject } from '@readable/styled-system/types';
 
   export let open: boolean;

--- a/packages/ui/src/components/Modal.svelte
+++ b/packages/ui/src/components/Modal.svelte
@@ -2,7 +2,7 @@
   import { css } from '@readable/styled-system/css';
   import { fade, fly } from 'svelte/transition';
   import { scrollLock } from '../actions';
-  import Dialog from './Dialog.svelte';
+  import Dialog from './dialog/Dialog.svelte';
   import type { SystemStyleObject } from '@readable/styled-system/types';
 
   export let open = false;

--- a/packages/ui/src/components/dialog/Dialog.svelte
+++ b/packages/ui/src/components/dialog/Dialog.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { css } from '@readable/styled-system/css';
   import { createEventDispatcher } from 'svelte';
+  import { dialogStore } from './store';
 
   export let open = false;
 
@@ -9,8 +10,10 @@
   let dialogElement: HTMLDialogElement;
   $: if (open) {
     dialogElement?.showModal();
+    dialogStore.update((prev) => [...prev, dialogElement]);
   } else {
     dialogElement?.close();
+    dialogStore.update((prev) => prev.filter((el) => el !== dialogElement));
   }
 
   function handleClose() {

--- a/packages/ui/src/components/dialog/index.ts
+++ b/packages/ui/src/components/dialog/index.ts
@@ -1,0 +1,2 @@
+export { default as Dialog } from './Dialog.svelte';
+export * from './store';

--- a/packages/ui/src/components/dialog/store.ts
+++ b/packages/ui/src/components/dialog/store.ts
@@ -1,0 +1,4 @@
+import { writable } from 'svelte/store';
+
+// 열린 dialog의 목록을 저장
+export const dialogStore = writable<HTMLElement[]>([]);

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -2,7 +2,7 @@ export { default as Alert } from './Alert.svelte';
 export { default as Button } from './Button.svelte';
 export { default as Checkbox } from './Checkbox.svelte';
 export { default as Chip } from './Chip.svelte';
-export { default as Dialog } from './Dialog.svelte';
+export { Dialog, dialogStore } from './dialog';
 export { default as FormField } from './FormField.svelte';
 export { default as FormValidationMessage } from './FormValidationMessage.svelte';
 export { default as Helmet } from './Helmet.svelte';

--- a/packages/ui/src/notification/toast/Item.svelte
+++ b/packages/ui/src/notification/toast/Item.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { css } from '@readable/styled-system/css';
+  import { css, cx } from '@readable/styled-system/css';
   import { center, flex } from '@readable/styled-system/patterns';
   import { backInOut, expoInOut, linear, sineInOut } from 'svelte/easing';
   import { tweened } from 'svelte/motion';
@@ -22,19 +22,22 @@
 </script>
 
 <div
-  class={flex({
-    align: 'center',
-    borderRadius: '10px',
-    paddingX: '4px',
-    width: 'fit',
-    minWidth: '44px',
-    maxWidth: '402px',
-    height: '38px',
-    backgroundColor: { base: 'gray.100', _dark: 'darkgray.800' },
-    boxShadow: 'strong',
-    overflow: 'hidden',
-    pointerEvents: 'auto',
-  })}
+  class={cx(
+    'toast-item',
+    flex({
+      align: 'center',
+      borderRadius: '10px',
+      paddingX: '4px',
+      width: 'fit',
+      minWidth: '44px',
+      maxWidth: '402px',
+      height: '38px',
+      backgroundColor: { base: 'gray.100', _dark: 'darkgray.800' },
+      boxShadow: 'strong',
+      overflow: 'hidden',
+      pointerEvents: 'auto',
+    }),
+  )}
   in:scale={{ duration: 400, easing: backInOut }}
   out:scale={{ duration: 400, delay: 600, easing: backInOut }}
 >

--- a/packages/ui/src/notification/toast/Provider.svelte
+++ b/packages/ui/src/notification/toast/Provider.svelte
@@ -1,20 +1,38 @@
 <script lang="ts">
   import { flex } from '@readable/styled-system/patterns';
+  import { portal } from '../../actions';
+  import { dialogStore } from '../../components';
   import Item from './Item.svelte';
   import { store } from './store';
+
+  let toastProviderEl: HTMLElement;
+
+  $: if (toastProviderEl) {
+    if ($store.length > 0) {
+      toastProviderEl.showPopover();
+    } else {
+      // 마지막 토스트 out transition 모두 끝나면 hidePopover
+      const lastToast = toastProviderEl.querySelector('.toast-item');
+      lastToast?.addEventListener('outroend', () => toastProviderEl.hidePopover(), { once: true });
+    }
+  }
 </script>
 
 <div
+  bind:this={toastProviderEl}
   class={flex({
+    alignItems: 'flex-start',
+    justifyContent: 'flex-end',
     direction: 'column',
     gap: '8px',
-    position: 'fixed',
-    zIndex: '100',
-    bottom: '20px',
-    paddingLeft: '20px',
     width: 'screen',
+    height: 'screen',
+    paddingLeft: '20px',
+    paddingBottom: '20px',
     pointerEvents: 'none',
   })}
+  popover="manual"
+  use:portal={$dialogStore.at(-1)}
 >
   {#each $store as toast (toast.id)}
     <Item {toast} />


### PR DESCRIPTION
토스트를 dialog 위에 띄우기 위해 popover로 만듦
- 토스트가 1개 이상 있을 때 showPopover
- 토스트가 없을 때는 마지막 toastItem의 outroend 이벤트를 기다려서 hidePopover

토스트 x 버튼으로 닫을 수 있도록 dialog 위에 올림
- dialogStore에 열린 dialog들의 목록을 관리
- toastProvider는 portal을 통해 맨 위에 열린 dialog에 들어감