### PR TITLE
ToastProvider가 popover가 아니어도 됨

### DIFF
--- a/packages/ui/src/notification/toast/Provider.svelte
+++ b/packages/ui/src/notification/toast/Provider.svelte
@@ -4,34 +4,18 @@
   import { dialogStore } from '../../components';
   import Item from './Item.svelte';
   import { store } from './store';
-
-  let toastProviderEl: HTMLElement;
-
-  $: if (toastProviderEl) {
-    if ($store.length > 0) {
-      toastProviderEl.showPopover();
-    } else {
-      // 마지막 토스트 out transition 모두 끝나면 hidePopover
-      const lastToast = toastProviderEl.querySelector('.toast-item');
-      lastToast?.addEventListener('outroend', () => toastProviderEl.hidePopover(), { once: true });
-    }
-  }
 </script>
 
 <div
-  bind:this={toastProviderEl}
   class={flex({
-    alignItems: 'flex-start',
-    justifyContent: 'flex-end',
     direction: 'column',
     gap: '8px',
-    width: 'screen',
-    height: 'screen',
+    position: 'fixed',
+    zIndex: '100',
+    bottom: '20px',
     paddingLeft: '20px',
-    paddingBottom: '20px',
     pointerEvents: 'none',
   })}
-  popover="manual"
   use:portal={$dialogStore.at(-1)}
 >
   {#each $store as toast (toast.id)}


### PR DESCRIPTION
topmost dialog에 넣어주니까 굳이 popover일 필요가 없음. 괜히 어렵게 했다. portal만 빼고 모두 원상복구