### PR TITLE
linkEditPopover에서 currentLink가 있을 때만 defaultLink를 unfurlLink함

### DIFF
--- a/packages/ui/src/tiptap/menus/link-edit-popover/Component.svelte
+++ b/packages/ui/src/tiptap/menus/link-edit-popover/Component.svelte
@@ -29,8 +29,12 @@
   };
 
   const loadLink = async (href: string) => {
-    const resp = await handleLink(href);
-    linkDraft = resp.url ? `${resp.host}${resp.url}` : href;
+    if (currentLink) {
+      const resp = await handleLink(href);
+      linkDraft = resp.url ? `${resp.host}${resp.url}` : href;
+    } else {
+      linkDraft = href;
+    }
   };
 
   $: loadLink(defaultLink);


### PR DESCRIPTION
`asdf`처럼 valid link structure가 아닌 텍스트에 인라인 링크를 걸려고 할 때 불필요한 unfurlLink를 시도하고 에러 응답을 받고 있음