### PR TITLE
Dialog 열려있을 때만 렌더링하고 portal 사용

### DIFF
--- a/packages/ui/src/components/dialog/Dialog.svelte
+++ b/packages/ui/src/components/dialog/Dialog.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { css } from '@readable/styled-system/css';
   import { createEventDispatcher } from 'svelte';
+  import { portal } from '../../actions';
   import { dialogStore } from './store';
 
   export let open = false;
@@ -23,21 +24,22 @@
   }
 </script>
 
-<dialog
-  bind:this={dialogElement}
-  class={css({
-    'width': 'full',
-    'height': 'full',
-    'maxWidth': '[unset]',
-    'maxHeight': '[unset]',
-    '& ::backdrop': {
-      display: 'none',
-    },
-  })}
-  on:close={handleClose}
->
-  {#if open}
-    <!-- NOTE: dialog 닫혀있을 때는 scrollLock 등 사이드 이펙트 안 일어나게 아예 렌더링 안 함 -->
+{#if open}
+  <!-- NOTE: dialog 닫혀있을 때는 scrollLock 등 사이드 이펙트 안 일어나게 아예 렌더링 안 함 -->
+  <dialog
+    bind:this={dialogElement}
+    class={css({
+      'width': 'full',
+      'height': 'full',
+      'maxWidth': '[unset]',
+      'maxHeight': '[unset]',
+      '& ::backdrop': {
+        display: 'none',
+      },
+    })}
+    on:close={handleClose}
+    use:portal
+  >
     <slot />
-  {/if}
-</dialog>
+  </dialog>
+{/if}


### PR DESCRIPTION
- portal 사용해서 body에 렌더링함 -> 이제 PageList 밑에 있는 모달들을 드래그래도 ghost가 안 생김
- dialog 내용 뿐만 아니라 dialog 전체를 open 상태일 때 렌더링함 (body에 속 빈 dialog가 잔뜩 쌓여있는 게 보기 안 좋음)