### PR TITLE
페이지 제목 따로 graphql 필드로 추출함

### DIFF
--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -231,6 +231,7 @@ type Page implements IPage {
   site: Site!
   slug: String!
   state: PageState!
+  title: String!
 }
 
 type PageContentContributor {
@@ -368,6 +369,7 @@ type PublicPage implements IPage {
   parent: PublicPage
   slug: String!
   state: PageState!
+  title: String!
 }
 
 type PublicPageContent {

--- a/apps/api/src/graphql/page.ts
+++ b/apps/api/src/graphql/page.ts
@@ -143,6 +143,25 @@ Page.implement({
 
     site: t.field({ type: Site, resolve: (page) => page.siteId }),
 
+    title: t.string({
+      resolve: async (page, _, ctx) => {
+        const loader = ctx.loader({
+          name: 'PageContentStates.title(pageId)',
+          load: async (ids: string[]) => {
+            return await db
+              .select({ pageId: PageContentStates.pageId, title: PageContentStates.title })
+              .from(PageContentStates)
+              .where(inArray(PageContentStates.pageId, ids));
+          },
+          key: (row) => row.pageId,
+        });
+
+        const pageContentState = await loader.load(page.id);
+
+        return pageContentState.title ?? '(제목 없음)';
+      },
+    }),
+
     content: t.field({
       type: PageContentState,
       resolve: async (page, _, ctx) => {
@@ -303,6 +322,25 @@ PublicPage.implement({
   interfaces: [IPage],
 
   fields: (t) => ({
+    title: t.string({
+      resolve: async (page, _, ctx) => {
+        const loader = ctx.loader({
+          name: 'PageContents.title(pageId)',
+          load: async (ids: string[]) => {
+            return await db
+              .select({ pageId: PageContents.pageId, title: PageContents.title })
+              .from(PageContents)
+              .where(inArray(PageContents.pageId, ids));
+          },
+          key: (row) => row.pageId,
+        });
+
+        const pageContent = await loader.load(page.id);
+
+        return pageContent.title ?? '(제목 없음)';
+      },
+    }),
+
     content: t.field({
       type: PublicPageContent,
       resolve: async (page, _, ctx) => {

--- a/apps/dashboard/src/routes/(default)/[teamId]/[siteId]/(page)/[pageId]/Breadcrumb.svelte
+++ b/apps/dashboard/src/routes/(default)/[teamId]/[siteId]/(page)/[pageId]/Breadcrumb.svelte
@@ -14,25 +14,17 @@
       fragment PagePage_Breadcrumb_query on Query {
         page(pageId: $pageId) {
           id
+          title
 
           category {
             id
             name
           }
 
-          content {
-            id
-            title
-          }
-
           # NOTE: maxDepth = 2
           parent {
             id
-
-            content {
-              id
-              title
-            }
+            title
           }
 
           site {
@@ -79,7 +71,7 @@
           aria-current={current ? 'page' : undefined}
           href={`/${$query.page.site.team.id}/${$query.page.site.id}/${page.id}`}
         >
-          {page.content.title}
+          {page.title}
         </a>
       </li>
     {/each}

--- a/apps/dashboard/src/routes/(default)/[teamId]/[siteId]/(page)/[pageId]/Editor.svelte
+++ b/apps/dashboard/src/routes/(default)/[teamId]/[siteId]/(page)/[pageId]/Editor.svelte
@@ -121,11 +121,7 @@
 
         ... on Page {
           id
-
-          content {
-            id
-            title
-          }
+          title
         }
 
         ... on UnfurlLinkUrl {
@@ -403,7 +399,7 @@
         const resp = await unfurlLink({ siteId: $query.page.site.id, url });
         return resp.__typename === 'Page'
           ? {
-              name: resp.content.title,
+              name: resp.title,
               href: `page:///${resp.id}`,
               host: $page.url.origin,
               url: `/${$query.page.site.team.id}/${$query.page.site.id}/${resp.id}`,

--- a/apps/dashboard/src/routes/(default)/[teamId]/[siteId]/+layout.svelte
+++ b/apps/dashboard/src/routes/(default)/[teamId]/[siteId]/+layout.svelte
@@ -51,11 +51,7 @@
           id
           state
           hasUnpublishedChanges
-
-          content {
-            id
-            title
-          }
+          title
         }
       }
     }

--- a/apps/dashboard/src/routes/(default)/[teamId]/[siteId]/@page-tree/PageItem.svelte
+++ b/apps/dashboard/src/routes/(default)/[teamId]/[siteId]/@page-tree/PageItem.svelte
@@ -222,7 +222,7 @@
             flex: '1',
           })}
         >
-          {item.content.title}
+          {item.title}
         </span>
         <Menu disableAutoUpdate offset={2} placement="bottom-start">
           <div
@@ -372,7 +372,7 @@
     bind:open={deletePageOpen}
   >
     <svelte:fragment slot="title">
-      "{item.content?.title ?? '(제목 없음)'}" 페이지를 삭제하시겠어요?
+      "{item.title}" 페이지를 삭제하시겠어요?
     </svelte:fragment>
     <svelte:fragment slot="content">삭제된 페이지는 복구할 수 없습니다</svelte:fragment>
 

--- a/apps/dashboard/src/routes/(default)/[teamId]/[siteId]/@page-tree/types.d.ts
+++ b/apps/dashboard/src/routes/(default)/[teamId]/[siteId]/@page-tree/types.d.ts
@@ -19,9 +19,7 @@ export type PageData = {
   };
   order: string;
   recursiveChildCount: number;
-  content: {
-    title: string;
-  };
+  title: string;
   parent?:
     | {
         id: string;

--- a/apps/dashboard/src/routes/(default)/[teamId]/[siteId]/LeftSideBar.svelte
+++ b/apps/dashboard/src/routes/(default)/[teamId]/[siteId]/LeftSideBar.svelte
@@ -39,16 +39,12 @@
             state
             order
             recursiveChildCount
+            title
             __typename
 
             category {
               id
               slug
-            }
-
-            content {
-              id
-              title
             }
 
             parent {
@@ -62,16 +58,12 @@
               state
               order
               recursiveChildCount
+              title
               __typename
 
               category {
                 id
                 slug
-              }
-
-              content {
-                id
-                title
               }
 
               parent {

--- a/apps/usersite/src/routes/(default)/+layout.svelte
+++ b/apps/usersite/src/routes/(default)/+layout.svelte
@@ -38,19 +38,18 @@
 
       searchPublicPage(query: $searchQuery) {
         estimatedTotalHits
+
         hits {
           highlight {
             title
             subtitle
             text
           }
+
           page {
             id
             slug
-
-            content {
-              title
-            }
+            title
 
             ...PageUrl_publicPage
           }

--- a/apps/usersite/src/routes/(default)/Navigation.svelte
+++ b/apps/usersite/src/routes/(default)/Navigation.svelte
@@ -30,11 +30,7 @@
             state
             order
             slug
-
-            content {
-              id
-              title
-            }
+            title
 
             parent {
               id
@@ -46,11 +42,7 @@
               state
               order
               slug
-
-              content {
-                id
-                title
-              }
+              title
 
               parent {
                 id
@@ -178,7 +170,7 @@
                 $treeOpenState[page.id] = true;
               }}
             >
-              {page.content.title}
+              {page.title}
             </a>
             {#if page.children.length > 0}
               <button
@@ -230,7 +222,7 @@
                       aria-current={childPage.id === currentPageId ? 'page' : undefined}
                       href={pageUrl(childPage)}
                     >
-                      {childPage.content.title}
+                      {childPage.title}
                     </a>
                   </li>
                 {/each}

--- a/apps/usersite/src/routes/(default)/SearchBar.svelte
+++ b/apps/usersite/src/routes/(default)/SearchBar.svelte
@@ -97,19 +97,17 @@
     query SearchBar_Query($query: String!) @manual {
       searchPublicPage(query: $query) {
         estimatedTotalHits
+
         hits {
           highlight {
             title
             subtitle
             text
           }
+
           page {
             id
-            slug
-
-            content {
-              title
-            }
+            title
 
             ...PageUrl_publicPage
           }
@@ -124,11 +122,7 @@
         answer
         pages {
           id
-          slug
-
-          content {
-            title
-          }
+          title
 
           ...PageUrl_publicPage
         }
@@ -541,9 +535,9 @@
                       },
                       'truncate': true,
                     })}
-                    aria-label={result.page.content.title}
+                    aria-label={result.page.title}
                   >
-                    {@html result.highlight?.title || result.page.content.title}
+                    {@html result.highlight?.title || result.page.title}
                   </h3>
                   {#if result.highlight?.text}
                     <p
@@ -630,7 +624,7 @@
                               textUnderlineOffset: '3px',
                             })}
                           >
-                            {page.content.title}
+                            {page.title}
                           </span>
                         </a>
                       </li>

--- a/apps/usersite/src/routes/(default)/[...slug]/Breadcrumb.svelte
+++ b/apps/usersite/src/routes/(default)/[...slug]/Breadcrumb.svelte
@@ -12,11 +12,7 @@
       fragment PagePage_Breadcrumb_publicPage on PublicPage {
         id
         slug
-
-        content {
-          id
-          title
-        }
+        title
 
         category {
           id
@@ -26,11 +22,7 @@
         parent {
           id
           slug
-
-          content {
-            id
-            title
-          }
+          title
 
           ...PageUrl_publicPage
         }
@@ -61,14 +53,14 @@
     {#if $publicPage.parent}
       <li>
         <a href={pageUrl($publicPage.parent)}>
-          {$publicPage.parent.content.title}
+          {$publicPage.parent.title}
         </a>
         <span class={css({ color: 'neutral.50' })} aria-hidden="true">/</span>
       </li>
     {/if}
     <li>
       <a aria-current="page" href={pageUrl($publicPage)}>
-        {$publicPage.content.title}
+        {$publicPage.title}
       </a>
     </li>
   </ol>


### PR DESCRIPTION
페이지 트리나 빵조각 등 page title을 보여줄 일이 많은데 그럴 때마다 page content 전체를 불러오지 않도록 함
