### PR TITLE
Menu, MenuItem 키보드 내비게이션 수정

### DIFF
--- a/packages/ui/src/components/MenuItem.svelte
+++ b/packages/ui/src/components/MenuItem.svelte
@@ -35,12 +35,16 @@
     {};
 
   let close = getContext<undefined | (() => void)>('close');
+
+  let focused = false;
 </script>
 
 <svelte:element
   this={element}
   role="menuitem"
-  tabindex="0"
+  tabindex={focused ? 0 : -1}
+  on:focus={() => (focused = true)}
+  on:blur={() => (focused = false)}
   on:click
   on:click={close}
   {...external && {


### PR DESCRIPTION
- MenuItem (listbox as popup) 항목에 roving tabindex 적용
- Menu (combobox)에 포커스가 있을 때 ArrowDown 키 누르면 listbox를 열고 첫번째 항목에 포커스
- listbox 내에서 tab 키 누르면 popup을 닫고 combobox 기준으로 포커스 이동

@mu-hun 감사합니다!