### PR TITLE
resizable table

### DIFF
--- a/apps/dashboard/src/routes/(default)/[teamId]/[siteId]/(page)/[pageId]/+page.svelte
+++ b/apps/dashboard/src/routes/(default)/[teamId]/[siteId]/(page)/[pageId]/+page.svelte
@@ -199,7 +199,7 @@
         <div
           class={css({
             position: 'absolute',
-            zIndex: '1',
+            zIndex: '30',
             backgroundColor: 'surface.primary',
             width: 'full',
             pointerEvents: 'none',

--- a/packages/ui/src/tiptap/lib/DomOutputSpecRenderer.svelte
+++ b/packages/ui/src/tiptap/lib/DomOutputSpecRenderer.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import type { DOMOutputSpec } from '@tiptap/pm/model';
+
+  export let domOutputSpec: DOMOutputSpec | undefined;
+
+  let element: HTMLElement;
+
+  function createElementFromSpec(spec: DOMOutputSpec): HTMLElement {
+    const [tag, attrs, ...children] = spec as [string, Record<string, string>, ...DOMOutputSpec[]];
+    const el = document.createElement(tag as string);
+
+    if (attrs && typeof attrs === 'object') {
+      for (const [key, value] of Object.entries(attrs)) {
+        el.setAttribute(key, value as string);
+      }
+    }
+
+    for (const child of children) {
+      if (typeof child === 'string') {
+        el.append(document.createTextNode(child));
+      } else {
+        el.append(createElementFromSpec(child as DOMOutputSpec));
+      }
+    }
+
+    return el;
+  }
+
+  $: if (domOutputSpec) {
+    element = createElementFromSpec(domOutputSpec);
+  }
+
+  let tag: keyof HTMLElementTagNameMap | undefined;
+  $: if (element) {
+    tag = element.tagName.toLowerCase() as keyof HTMLElementTagNameMap;
+  }
+</script>
+
+{#if element}
+  <svelte:element this={tag} bind:this={element} {...$$restProps}>
+    {@html element.innerHTML}
+  </svelte:element>
+{/if}

--- a/packages/ui/src/tiptap/lib/index.ts
+++ b/packages/ui/src/tiptap/lib/index.ts
@@ -1,4 +1,5 @@
 export { createNodeView } from './create';
+export { default as DomOutputSpecRenderer } from './DomOutputSpecRenderer.svelte';
 export { default as NodeView } from './NodeView.svelte';
 export { default as NodeViewContentEditable } from './NodeViewContentEditable.svelte';
 export type { NodeViewProps } from './renderer';

--- a/packages/ui/src/tiptap/menus/bubble/Component.svelte
+++ b/packages/ui/src/tiptap/menus/bubble/Component.svelte
@@ -140,6 +140,7 @@
     backgroundColor: 'background.overlay',
     height: '42px',
     boxShadow: 'strong',
+    zIndex: '20',
   })}
 >
   {#if selectedBlocks.length === 1}

--- a/packages/ui/src/tiptap/node-views/table/Component.svelte
+++ b/packages/ui/src/tiptap/node-views/table/Component.svelte
@@ -3,7 +3,7 @@
   import { center } from '@readable/styled-system/patterns';
   import { mergeAttributes } from '@tiptap/core';
   import { createColGroup } from '@tiptap/extension-table';
-  import { NodeView, NodeViewContentEditable } from '../../lib';
+  import { DomOutputSpecRenderer, NodeView, NodeViewContentEditable } from '../../lib';
   import type { NodeViewProps } from '../../lib';
 
   type $$Props = NodeViewProps;
@@ -18,42 +18,78 @@
   // export let getPos: NodeViewProps['getPos'];
   // export let updateAttributes: NodeViewProps['updateAttributes'];
 
-  $: props = createColGroup(node, extension.options.cellMinWidth);
+  $: ({ colgroup, tableWidth, tableMinWidth } = createColGroup(node, extension.options.cellMinWidth));
 </script>
 
-<NodeView style={css.raw({ position: 'relative' })}>
+<NodeView>
   <table
     {...mergeAttributes(extension.options.HTMLAttributes, HTMLAttributes, {
-      class: css({ width: 'full' }),
-      style: props.tableWidth ? `width: ${props.tableWidth}` : `min-width: ${props.tableMinWidth}`,
+      class: css({ position: 'relative', border: '1px solid', borderColor: 'neutral.30', borderBottom: 'none' }),
+      style: tableWidth ? `width: ${tableWidth}` : `min-width: ${tableMinWidth}`,
     })}
   >
+    <DomOutputSpecRenderer contenteditable={false} domOutputSpec={colgroup} />
     <NodeViewContentEditable as="tbody" />
+    <div
+      class={center({
+        position: 'absolute',
+        zIndex: '10',
+        left: '1/2',
+        bottom: '0',
+        translate: 'auto',
+        translateX: '-1/2',
+        translateY: '1/2',
+      })}
+      contenteditable={false}
+    >
+      <button
+        class={css({
+          borderWidth: '1px',
+          borderRadius: '4px',
+          textStyle: '14m',
+          paddingX: '4px',
+          paddingY: '2px',
+          backgroundColor: 'surface.primary',
+          _hover: {
+            backgroundColor: 'surface.secondary',
+          },
+        })}
+        type="button"
+        on:click={() => editor?.chain().addRowAfter().run()}
+      >
+        추가
+      </button>
+    </div>
+
+    <div
+      class={center({
+        position: 'absolute',
+        zIndex: '10',
+        top: '1/2',
+        right: '0',
+        translate: 'auto',
+        translateX: '1/2',
+        translateY: '-1/2',
+      })}
+      contenteditable={false}
+    >
+      <button
+        class={css({
+          borderWidth: '1px',
+          borderRadius: '4px',
+          textStyle: '14m',
+          paddingX: '4px',
+          paddingY: '2px',
+          backgroundColor: 'surface.primary',
+          _hover: {
+            backgroundColor: 'surface.secondary',
+          },
+        })}
+        type="button"
+        on:click={() => editor?.commands.addColumnAfter()}
+      >
+        추가
+      </button>
+    </div>
   </table>
-
-  <div
-    class={center({ position: 'absolute', left: '0', right: '0', bottom: '0', translate: 'auto', translateY: '1/2' })}
-    contenteditable={false}
-  >
-    <button
-      class={css({ borderWidth: '1px', borderRadius: '4px', textStyle: '14m' })}
-      type="button"
-      on:click={() => editor?.chain().addRowAfter().run()}
-    >
-      추가
-    </button>
-  </div>
-
-  <div
-    class={center({ position: 'absolute', top: '0', bottom: '0', right: '0', translate: 'auto', translateX: '1/2' })}
-    contenteditable={false}
-  >
-    <button
-      class={css({ borderWidth: '1px', borderRadius: '4px', textStyle: '14m' })}
-      type="button"
-      on:click={() => editor?.commands.addColumnAfter()}
-    >
-      추가
-    </button>
-  </div>
 </NodeView>

--- a/packages/ui/src/tiptap/schema.ts
+++ b/packages/ui/src/tiptap/schema.ts
@@ -158,14 +158,10 @@ export const basicExtensions = [
     content: 'paragraph (paragraph | bulletList | orderedList)*',
   }),
   extendNodeToNodeView(Table, TableComponent).configure({
-    resizable: false, // https://github.com/ueberdosis/tiptap/issues/1766
-    HTMLAttributes: {
-      class: css({
-        border: '1px solid',
-        borderColor: 'neutral.30',
-        borderCollapse: 'collapse',
-      }),
-    },
+    resizable: true,
+    lastColumnResizable: false,
+    cellMinWidth: 50,
+    allowTableNodeSelection: true,
   }),
   TableRow,
   TableHeader.configure({

--- a/packages/ui/styles/prose.css
+++ b/packages/ui/styles/prose.css
@@ -47,6 +47,35 @@
     }
   }
 
+  table {
+    border-collapse: collapse;
+    table-layout: fixed;
+    width: 100%;
+  }
+
+  td,
+  th {
+    vertical-align: top;
+    box-sizing: border-box;
+    position: relative;
+  }
+
+  .column-resize-handle {
+    position: absolute;
+    right: -2px;
+    top: 0;
+    bottom: 0;
+    width: 4px;
+    z-index: 5;
+    background-color: #adf;
+    pointer-events: none;
+  }
+
+  .resize-cursor {
+    cursor: ew-resize;
+    cursor: col-resize;
+  }
+
   .selectedCell {
     background-color: #b3d4fc66;
   }


### PR DESCRIPTION
- prose.css에 테이블 관련 스타일 이것저것 추가
- table configure 이것저것
- `DomOutputSpecRenderer`: DOMOutputSpec을 렌더링하는 스벨트 컴포넌트
- `DOMOutputSpec`인 `colgroup` 을 `DomOutputSpecRenderer`로 렌더링함. 컬럼 리사이징이 이제 동작함
- 추가 버튼 스타일 수정
- 컬럼 리사이즈 커서 < 행/열 추가 버튼 < 버블 메뉴 < 띠 배너 순으로 zIndex 조정함