### PR TITLE
QA-543 유저사이트 모바일 사이드바에서 scroll lock 제거

### DIFF
--- a/apps/usersite/src/routes/(default)/MobileSidebar.svelte
+++ b/apps/usersite/src/routes/(default)/MobileSidebar.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { css } from '@readable/styled-system/css';
   import { flex } from '@readable/styled-system/patterns';
-  import { scrollLock } from '@readable/ui/actions';
   import { Icon } from '@readable/ui/components';
   import { fade, fly } from 'svelte/transition';
   import CloseIcon from '~icons/lucide/x';
@@ -54,7 +53,6 @@
         borderRightWidth: '1px',
         borderRightColor: 'border.primary',
       })}
-      use:scrollLock
       in:fly={{ x: -200, duration: 200 }}
       out:fly={{ x: -200, duration: 200 }}
     >
@@ -81,8 +79,8 @@
           justifyContent: 'space-between',
           flex: '1',
           overflow: 'auto',
+          overscrollBehavior: 'contain',
         })}
-        data-scroll-lock-ignore
       >
         <div class={css({ padding: '16px', paddingBottom: '80px' })}>
           <slot name="navigation" />


### PR DESCRIPTION
- scroll lock이 모바일 브라우저에서 QA-543 을 유발함
- 오른쪽에 메인 콘텐츠가 살짝 보이니까 scroll lock 없어도 무방할듯
- 대신 스크롤되는 영역에 `overscroll-behavior: contain` 이라도 적용해 둠