### PR TITLE
버블 메뉴의 항목들이 맥락에 맞게 나오도록 함

### DIFF
--- a/packages/ui/src/tiptap/menus/bubble/extension.ts
+++ b/packages/ui/src/tiptap/menus/bubble/extension.ts
@@ -46,7 +46,7 @@ export const BubbleMenu = Extension.create({
                 this.editor.commands.showLinkEditPopoverForActiveSelection();
               };
 
-              bubbleComponent?.$set({ from: selection.from, to: selection.to, openLinkEditPopover });
+              bubbleComponent?.$set({ openLinkEditPopover });
 
               if (
                 selection.empty ||


### PR DESCRIPTION
- selection이 "`inlineContent: true`이고 `size > 0`인 node"를 포함하고 있어야 mark 관련 메뉴를 보여줌