### PR TITLE
검색 버튼에 단축키 표시

### DIFF
--- a/apps/usersite/src/lib/stores/ui.ts
+++ b/apps/usersite/src/lib/stores/ui.ts
@@ -3,3 +3,4 @@ import { writable } from 'svelte/store';
 export const mobileNavOpen = writable(false);
 export const treeOpenState = writable<Record<string, boolean>>({});
 export const searchBarOpen = writable(false);
+export const hasCmd = writable(false);

--- a/apps/usersite/src/routes/(default)/+layout.svelte
+++ b/apps/usersite/src/routes/(default)/+layout.svelte
@@ -5,13 +5,14 @@
   import { setContext } from 'svelte';
   import { writable } from 'svelte/store';
   import { swipe } from 'svelte-gestures';
+  import CommandIcon from '~icons/lucide/command';
   import SearchIcon from '~icons/lucide/search';
   import ReadableIcon from '~icons/rdbl/readable';
   import { browser } from '$app/environment';
   import { env } from '$env/dynamic/public';
   import { graphql } from '$graphql';
   import { Img } from '$lib/components';
-  import { mobileNavOpen, searchBarOpen } from '$lib/stores/ui';
+  import { hasCmd, mobileNavOpen, searchBarOpen } from '$lib/stores/ui';
   import MobileSidebar from './MobileSidebar.svelte';
   import Navigation from './Navigation.svelte';
   import SearchBar from './SearchBar.svelte';
@@ -226,9 +227,26 @@
               {/if}
             </span>
           </div>
-          <!-- <div class={flex({ alignItems: 'center', gap: '1ch' })}>
-            TODO: 키보드 단축키 표시
-          </div> -->
+          <div
+            class={flex({
+              borderRadius: '4px',
+              paddingX: '6px',
+              paddingY: '2px',
+              alignItems: 'center',
+              gap: '4px',
+              backgroundColor: 'surface.tertiary',
+              color: 'text.tertiary',
+              textStyle: '12sb',
+              borderWidth: '1px',
+            })}
+          >
+            {#if $hasCmd}
+              <Icon icon={CommandIcon} size={12} />
+            {:else}
+              <span>Ctrl</span>
+            {/if}
+            <span>K</span>
+          </div>
         </button>
       </div>
       <button

--- a/apps/usersite/src/routes/+layout.server.ts
+++ b/apps/usersite/src/routes/+layout.server.ts
@@ -1,0 +1,5 @@
+export const load = (event) => {
+  return {
+    hasCmd: event.request.headers.get('user-agent')?.includes('Macintosh') || false,
+  };
+};

--- a/apps/usersite/src/routes/+layout.svelte
+++ b/apps/usersite/src/routes/+layout.svelte
@@ -1,5 +1,16 @@
 <script lang="ts">
   import '../app.css';
+
+  import { browser } from '$app/environment';
+  import { hasCmd } from '$lib/stores/ui';
+
+  export let data: { hasCmd: boolean };
+
+  hasCmd.set(data.hasCmd);
+
+  $: if (browser) {
+    hasCmd.set(navigator.platform.toUpperCase().includes('MAC') || /(ipad|iphone|ipod)/i.test(navigator.userAgent));
+  }
 </script>
 
 <slot />

--- a/apps/usersite/src/routes/+layout.ts
+++ b/apps/usersite/src/routes/+layout.ts
@@ -1,0 +1,3 @@
+export const load = (event) => {
+  return event.data;
+};


### PR DESCRIPTION
<img width="288" alt="스크린샷 2024-10-09 오후 5 15 04" src="https://github.com/user-attachments/assets/2280c783-cdac-4a67-9e30-8e7c31a122fc">

hasCmd 관련 로직을 루트 레이아웃으로 옮겼는데 거기엔 gql query가 없어서 #1196 이 당장은 필요 없게 되었어요