### PR TITLE
헤딩 블록을 선택해도 margin-top이 유지되도록 함

### DIFF
--- a/packages/ui/src/tiptap/extensions/block-selection.ts
+++ b/packages/ui/src/tiptap/extensions/block-selection.ts
@@ -1,4 +1,4 @@
-import { css } from '@readable/styled-system/css';
+import { css, cx } from '@readable/styled-system/css';
 import { Extension } from '@tiptap/core';
 import { NodeSelection, Plugin, PluginKey, Selection } from '@tiptap/pm/state';
 import { Decoration, DecorationSet } from '@tiptap/pm/view';
@@ -76,22 +76,25 @@ export const BlockSelectionHelper = Extension.create({
               decorations.push(
                 Decoration.node(pos, pos + node.nodeSize, {
                   nodeName: 'div',
-                  class: css({
-                    position: 'relative',
+                  class: cx(
+                    'block-selection-decoration',
+                    css({
+                      position: 'relative',
 
-                    _after: {
-                      content: '""',
-                      position: 'absolute',
-                      inset: '0',
-                      borderRadius: '4px',
-                      backgroundColor: '[#b3d4fc]',
-                      opacity: '40',
-                      transition: 'common',
-                      transitionTimingFunction: 'ease',
-                      willChange: 'background-color',
-                      pointerEvents: 'none',
-                    },
-                  }),
+                      _after: {
+                        content: '""',
+                        position: 'absolute',
+                        inset: '0',
+                        borderRadius: '4px',
+                        backgroundColor: '[#b3d4fc]',
+                        opacity: '40',
+                        transition: 'common',
+                        transitionTimingFunction: 'ease',
+                        willChange: 'background-color',
+                        pointerEvents: 'none',
+                      },
+                    }),
+                  ),
                 }),
               );
 

--- a/packages/ui/styles/prose.css
+++ b/packages/ui/styles/prose.css
@@ -19,16 +19,19 @@
     margin-top: var(--prosemirror-block-gap);
   }
 
-  & > * + h2 {
-    margin-top: calc(var(--prosemirror-block-gap) + 1em);
+  & > * + h2,
+  & > * + .block-selection-decoration:has(> h2) {
+    margin-top: calc(var(--prosemirror-block-gap) + 26px * 1);
   }
 
-  & > * + h3 {
-    margin-top: calc(var(--prosemirror-block-gap) + 0.75em);
+  & > * + h3,
+  & > * + .block-selection-decoration:has(> h3) {
+    margin-top: calc(var(--prosemirror-block-gap) + 22px * 0.75);
   }
 
-  & > * + h4 {
-    margin-top: calc(var(--prosemirror-block-gap) + 0.5em);
+  & > * + h4,
+  & > * + .block-selection-decoration:has(> h4) {
+    margin-top: calc(var(--prosemirror-block-gap) + 18px * 0.5);
   }
 
   & [data-color='gray'] {
@@ -82,10 +85,6 @@
     width: 4px;
     z-index: 5;
     background-color: #adf;
-    pointer-events: none;
-  }
-
-  .resize-cursor {
     cursor: ew-resize;
     cursor: col-resize;
   }


### PR DESCRIPTION
heading block을 선택하면 decoration div에 들어가게 되면서 기존 css가 동작하지 않아 레이아웃 시프트가 발생하고 있었음

..그리고 컬럼 리사이즈 핸들 cursor 속성이 동작하도록 함