### PR TITLE
QA-544 에디터에서 표 아래 행 추가 버튼 보여줄 공간 확보

### DIFF
--- a/packages/ui/src/tiptap/extensions/block-selection.ts
+++ b/packages/ui/src/tiptap/extensions/block-selection.ts
@@ -93,6 +93,12 @@ export const BlockSelectionHelper = Extension.create({
                           pointerEvents: 'none',
                         },
                       },
+                      ...(this.editor.isEditable && {
+                        '&:has(table)': {
+                          marginBottom: '[calc(var(--prosemirror-block-gap) * -1)]',
+                          paddingBottom: '23px',
+                        },
+                      }),
                     }),
                   ),
                 }),

--- a/packages/ui/src/tiptap/node-views/table/Component.svelte
+++ b/packages/ui/src/tiptap/node-views/table/Component.svelte
@@ -103,10 +103,12 @@
     'width': editor?.isEditable ? 'fit' : 'full',
 
     // 바깥으로 튀어나온 행/열 핸들과 행/열 추가 버튼이 보일 수 있도록 함
-    'marginTop': '[calc(-10px + var(--prosemirror-block-gap))]',
-    'paddingTop': '10px',
-    'marginBottom': '-23px',
-    'paddingBottom': '23px',
+    ...(editor?.isEditable && {
+      marginTop: '[calc(-10px + var(--prosemirror-block-gap))]',
+      paddingTop: '10px',
+      marginBottom: '[calc(var(--prosemirror-block-gap) * -1)]',
+      paddingBottom: '23px',
+    }),
 
     '.block-selection-decoration &': {
       marginTop: '0',


### PR DESCRIPTION
표 아래 행 추가 버튼이 다음 블록의 영역을 침범해서 다음 블록(확인 가능한 예: 탭)에 포인터를 올려도 표에 floating menu가 뜨는 문제가 있었음

에디터에서 편집 중에는 표 밑에 23px 확보하도록 함