### PR TITLE
에디터 플로팅 메뉴 레이아웃 시프트 고침

### DIFF
--- a/packages/ui/src/tiptap/menus/floating/extension.ts
+++ b/packages/ui/src/tiptap/menus/floating/extension.ts
@@ -119,11 +119,11 @@ export const FloatingMenu = Extension.create({
               cleanup?.();
               cleanup = autoUpdate(element, dom, async () => {
                 const style = window.getComputedStyle(element);
-                const marginLeft = Number.parseInt(style.marginLeft, 10) || 0;
-                const paddingLeft = Number.parseInt(style.paddingLeft, 10) || 0;
-                const paddingTop = Number.parseInt(style.paddingTop, 10) || 0;
+                const marginLeft = Number.parseFloat(style.marginLeft) || 0;
+                const paddingLeft = Number.parseFloat(style.paddingLeft) || 0;
+                const paddingTop = Number.parseFloat(style.paddingTop) || 0;
                 const scrollLeft = element.scrollLeft;
-                const lineHeight = Number.parseInt(style.lineHeight, 10) || Number.parseInt(style.fontSize, 10) * 1.5;
+                const lineHeight = Number.parseFloat(style.lineHeight) || Number.parseFloat(style.fontSize) * 1.5;
 
                 const { x, y } = await computePosition(element, dom, {
                   placement: 'left-start',


### PR DESCRIPTION
AS-IS: 블록을 선택하면 플로팅 메뉴가 1px정도 이동하는 경우가 있음. parseInt로 paddingLeft의 소수부를 잃어버려서 그렇다