### PR TITLE
drop cursor가 적당한 크기로 보이도록 함

### DIFF
--- a/apps/dashboard/src/routes/(default)/[teamId]/[siteId]/(page)/[pageId]/Editor.svelte
+++ b/apps/dashboard/src/routes/(default)/[teamId]/[siteId]/(page)/[pageId]/Editor.svelte
@@ -379,9 +379,13 @@
         'alignItems': 'center',
 
         '& > *': {
+          width: '720px',
+          overflowX: 'auto',
+        },
+
+        '& > [data-node-view]:has(table)': {
           width: 'full',
           paddingX: '[calc((100% - 720px) / 2)]',
-          overflowX: 'auto',
         },
       })}
       {awareness}

--- a/packages/ui/src/tiptap/menus/floating/extension.ts
+++ b/packages/ui/src/tiptap/menus/floating/extension.ts
@@ -120,7 +120,7 @@ export const FloatingMenu = Extension.create({
               cleanup = autoUpdate(element, dom, async () => {
                 const style = window.getComputedStyle(element);
                 const marginLeft = Number.parseFloat(style.marginLeft) || 0;
-                const paddingLeft = Number.parseFloat(style.paddingLeft) || 0;
+                const paddingLeft = element.querySelector('table') ? Number.parseFloat(style.paddingLeft) || 0 : 0;
                 const paddingTop = Number.parseFloat(style.paddingTop) || 0;
                 const scrollLeft = element.scrollLeft;
                 const lineHeight = Number.parseFloat(style.lineHeight) || Number.parseFloat(style.fontSize) * 1.5;


### PR DESCRIPTION
- 테이블을 가진 node view 이외에는 width 720px으로 다시 고정
- drop cursor도 720px로 보임
- 다만 테이블 밑에서는 drop cursor가 full width로 보임
- 인용구가 이상하게 보이는 문제도 함께 수정됨