### PR TITLE
에디터 전반적인 드래그 앤 드랍 경험 개선

### DIFF
--- a/apps/dashboard/src/routes/(default)/[teamId]/[siteId]/(page)/[pageId]/Editor.svelte
+++ b/apps/dashboard/src/routes/(default)/[teamId]/[siteId]/(page)/[pageId]/Editor.svelte
@@ -378,12 +378,8 @@
         alignItems: 'center',
 
         '& > *': {
-          width: '720px',
-          overflowX: 'auto',
-        },
-
-        '& > [data-node-view]:has(table)': {
           width: 'full',
+          overflowX: 'auto',
           paddingX: '[calc((100% - 720px) / 2)]',
         },
       })}

--- a/packages/ui/src/tiptap/menus/floating/Component.svelte
+++ b/packages/ui/src/tiptap/menus/floating/Component.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { css } from '@readable/styled-system/css';
+  import { css, cx } from '@readable/styled-system/css';
   import { flex } from '@readable/styled-system/patterns';
   import GripVerticalIcon from '~icons/lucide/grip-vertical';
   import PlusIcon from '~icons/lucide/plus';
@@ -85,9 +85,35 @@
     editor.commands.setTextSelection(pos);
     const child = dom.node.children[dom.offset];
 
-    event.dataTransfer.setDragImage(child, 0, 0);
+    const target = document.createElement('div');
+    target.className = cx(
+      'ProseMirror',
+      css({
+        width: '720px',
+        position: 'fixed',
+        backgroundColor: 'white',
+        overflow: 'hidden',
+
+        '& > *': {
+          width: 'full!',
+          margin: '0!',
+          padding: '0!',
+        },
+      }),
+    );
+
+    const cloned = child.cloneNode(true) as HTMLElement;
+
+    target.append(cloned);
+    document.body.append(target);
+
+    event.dataTransfer.setDragImage(target, 0, 0);
     event.dataTransfer.clearData();
     event.dataTransfer.effectAllowed = 'move';
+
+    setTimeout(() => {
+      target.remove();
+    }, 0);
 
     editor
       .chain()

--- a/packages/ui/src/tiptap/menus/floating/extension.ts
+++ b/packages/ui/src/tiptap/menus/floating/extension.ts
@@ -120,7 +120,7 @@ export const FloatingMenu = Extension.create({
               cleanup = autoUpdate(element, dom, async () => {
                 const style = window.getComputedStyle(element);
                 const marginLeft = Number.parseFloat(style.marginLeft) || 0;
-                const paddingLeft = element.querySelector('table') ? Number.parseFloat(style.paddingLeft) || 0 : 0;
+                const paddingLeft = Number.parseFloat(style.paddingLeft) || 0;
                 const paddingTop = Number.parseFloat(style.paddingTop) || 0;
                 const scrollLeft = element.scrollLeft;
                 const lineHeight = Number.parseFloat(style.lineHeight) || Number.parseFloat(style.fontSize) * 1.5;


### PR DESCRIPTION
- 플로팅 메뉴가 노드 좌우 바깥에서도 제대로 뜨도록 함
- 플로팅 메뉴를 통해 드래그 앤 드랍시 타겟 이미지가 정확히 나오도록 함
- 부작용: 드롭커서가 전체 너비로 뜸. 고칠 방법 찾지 못함.
